### PR TITLE
Add ability to override isSelfClosing

### DIFF
--- a/src/Traits/Tag.php
+++ b/src/Traits/Tag.php
@@ -256,6 +256,32 @@ abstract class Tag extends TreeObject
         return '>';
     }
 
+    /**
+     * Return whether or not the tag is self-closing.
+     *
+     * @param boolean $isSelfClosing whether the tag is self-closing
+     *
+     * @return boolean
+     */
+    public function getIsSelfClosing($isSelfClosing)
+    {
+        return $this->isSelfClosing;
+    }
+    
+    /**
+     * Force the tag to be self-closing or not.
+     *
+     * @param boolean $isSelfClosing whether the tag is self-closing
+     *
+     * @return $this
+     */
+    public function setIsSelfClosing($isSelfClosing)
+    {
+        $this->isSelfClosing = $isSelfClosing;
+        
+        return $this;
+    }
+
     ////////////////////////////////////////////////////////////////////
     /////////////////////////// MAGIC METHODS //////////////////////////
     ////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
If you have a custom tag/custom element that needs different self-closing rules (or one that isn't already defined in the code, such as `meta`), this PR adds the ability to override that behavior to ensure a tag is or is not self-closing.
